### PR TITLE
Added subtitle auto detecting feature

### DIFF
--- a/src/snappy.c
+++ b/src/snappy.c
@@ -248,8 +248,20 @@ main (int argc, char *argv[])
   gst_object_unref (engine->bus);
 
   /* Get uri to load */
-  if (uri_list)
+  if (uri_list) {
     uri = g_list_first (uri_list)->data;
+    /* based on video filename we can guess subtitle file (.srt files only) */
+    if (NULL == suburi) {     
+      gchar suburi_path_guessing[1024]; //buffer
+      gchar *uri_no_extension = strip_filename_extension(uri);  
+          
+      sprintf(suburi_path_guessing, "%s.srt", uri_no_extension);      
+      /* subtitle file exists, defaults for it */
+      if (g_file_test (g_filename_from_uri(suburi_path_guessing, NULL, NULL), G_FILE_TEST_EXISTS)) {        
+        suburi = suburi_path_guessing;
+      } 
+    } 
+  }
 
   /* Load engine and start interface */
   engine_load_uri (engine, uri);

--- a/src/utils.c
+++ b/src/utils.c
@@ -89,3 +89,26 @@ clean_brackets_in_uri (gchar * uri)
 
   return clean_uri;
 }
+
+gchar *
+strip_filename_extension(gchar* filename) {
+    gchar *retstr;
+    gchar *lastdot;
+
+    if (NULL == filename) {
+         return NULL;
+    }
+
+    if (NULL == (retstr = malloc (strlen (filename) + 1))) {
+        return NULL;
+    }
+
+    strcpy (retstr, filename);
+    lastdot = strrchr (retstr, '.');
+
+    if (NULL != lastdot) {
+        *lastdot = '\0';
+    }
+
+    return retstr;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -26,12 +26,14 @@
 #include <glib.h>
 #include <gio/gio.h>
 #include <gst/gst.h>
+ #include <string.h>
 
 G_BEGIN_DECLS
 
 gchar * cut_long_filename (gchar * filename, gint length);
 gchar * clean_uri (gchar * input_arg);
 gchar * clean_brackets_in_uri (gchar * uri);
+gchar * strip_filename_extension(gchar * filename);
 
 G_END_DECLS
 #endif /* __UTILS_H__ */


### PR DESCRIPTION
Snappy is a minimalist and awesome video player.
However it has not a basic feature among video player applications such as VLC or Gnome Videos (aka Totem): **detection and automatic loading subtitles**.
Currently Snappy can load subtitles if passing the "--subtitles" option from  command line.
It seems good but it would be a much better if "Snappy player" could to probe subtitles (in in the same video file directory) automatically and load when video is starting. And it is exactly what the PR is about.
The current PR add support for auto detecting/loading subtitles.
